### PR TITLE
feat-8: Add About page with family history, guide profiles, conservation, and ethics sections

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,6 +7,7 @@ import { Seasons } from "./pages/seasonsPage/Seasons";
 import { Contact } from "./pages/contactPage/Contact";
 import { Lodging } from "./pages/lodgingPage/Lodging";
 import { Packages } from "./pages/packagesPage/Packages";
+import { About } from "./pages/aboutPage/About";
 
 function App() {
   return (
@@ -19,6 +20,7 @@ function App() {
           <Route path="/contact" element={<Contact />} />
           <Route path="/lodging" element={<Lodging />} />
           <Route path="/packages" element={<Packages />} />
+          <Route path="/about" element={<About />} />
         </Routes>
         <Footer />
       </div>

--- a/src/__tests__/About.test.js
+++ b/src/__tests__/About.test.js
@@ -1,0 +1,200 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import { About } from "../pages/aboutPage/About";
+
+const mockStore = configureStore([]);
+
+describe("About Page", () => {
+  const initialState = {
+    aboutSlice: {
+      familyHistory: {
+        id: 1,
+        title: "Our Heritage",
+        content: "Founded in 1952...",
+        imageUrl: null,
+      },
+      guides: [
+        {
+          id: 1,
+          name: "Jake Wilson",
+          role: "Head Guide",
+          bio: "Experienced guide",
+          yearsExperience: 25,
+          specialties: ["Elk"],
+          imageUrl: null,
+        },
+        {
+          id: 2,
+          name: "Sarah Martinez",
+          role: "Senior Guide",
+          bio: "Wildlife biologist",
+          yearsExperience: 15,
+          specialties: ["Deer"],
+          imageUrl: null,
+        },
+      ],
+      conservation: {
+        id: 1,
+        title: "Conservation",
+        content: "We care about conservation",
+        practices: ["Practice 1"],
+      },
+      ethics: {
+        id: 1,
+        title: "Ethics",
+        content: "We have strong ethics",
+        principles: ["Principle 1"],
+      },
+      isAdminMode: false,
+      editingSection: null,
+    },
+  };
+
+  let store;
+
+  beforeEach(() => {
+    store = mockStore(initialState);
+    jest.clearAllTimers();
+  });
+
+  it("should render page header with title", () => {
+    render(
+      <Provider store={store}>
+        <About />
+      </Provider>
+    );
+    expect(screen.getByText("About Us")).toBeInTheDocument();
+  });
+
+  it("should render family history section", () => {
+    render(
+      <Provider store={store}>
+        <About />
+      </Provider>
+    );
+    expect(screen.getByText("Our Heritage")).toBeInTheDocument();
+    expect(screen.getByText(/Founded in 1952/)).toBeInTheDocument();
+  });
+
+  it("should render all guides", () => {
+    render(
+      <Provider store={store}>
+        <About />
+      </Provider>
+    );
+    expect(screen.getByText("Jake Wilson")).toBeInTheDocument();
+    expect(screen.getByText("Sarah Martinez")).toBeInTheDocument();
+  });
+
+  it("should render conservation section", () => {
+    render(
+      <Provider store={store}>
+        <About />
+      </Provider>
+    );
+    expect(screen.getByText("Conservation")).toBeInTheDocument();
+    expect(screen.getByText(/We care about conservation/)).toBeInTheDocument();
+  });
+
+  it("should render ethics section", () => {
+    render(
+      <Provider store={store}>
+        <About />
+      </Provider>
+    );
+    expect(screen.getByText("Ethics")).toBeInTheDocument();
+    expect(screen.getByText(/We have strong ethics/)).toBeInTheDocument();
+  });
+
+  it("should not show admin badge when not in admin mode", () => {
+    render(
+      <Provider store={store}>
+        <About />
+      </Provider>
+    );
+    expect(screen.queryByText("Admin Mode")).not.toBeInTheDocument();
+  });
+
+  it("should show admin badge when in admin mode", () => {
+    const adminState = {
+      ...initialState,
+      aboutSlice: { ...initialState.aboutSlice, isAdminMode: true },
+    };
+    const adminStore = mockStore(adminState);
+
+    render(
+      <Provider store={adminStore}>
+        <About />
+      </Provider>
+    );
+    expect(screen.getByText("Admin Mode")).toBeInTheDocument();
+  });
+
+  it("should toggle admin mode when heading is triple-clicked", () => {
+    jest.useFakeTimers();
+
+    render(
+      <Provider store={store}>
+        <About />
+      </Provider>
+    );
+
+    const heading = screen.getByText("About Us");
+    fireEvent.click(heading);
+    fireEvent.click(heading);
+    fireEvent.click(heading);
+
+    jest.advanceTimersByTime(500);
+
+    const actions = store.getActions();
+    expect(actions.length).toBeGreaterThan(0);
+    expect(actions[0].type).toBe("about/toggleAdminMode");
+
+    jest.useRealTimers();
+  });
+
+  it("should not show edit buttons when not in admin mode", () => {
+    render(
+      <Provider store={store}>
+        <About />
+      </Provider>
+    );
+    expect(screen.queryByText("Edit")).not.toBeInTheDocument();
+  });
+
+  it("should show edit buttons when in admin mode", () => {
+    const adminState = {
+      ...initialState,
+      aboutSlice: { ...initialState.aboutSlice, isAdminMode: true },
+    };
+    const adminStore = mockStore(adminState);
+
+    render(
+      <Provider store={adminStore}>
+        <About />
+      </Provider>
+    );
+    const editButtons = screen.getAllByText("Edit");
+    expect(editButtons.length).toBeGreaterThan(0);
+  });
+
+  it("should render AboutEditModal when editing", () => {
+    const editingState = {
+      ...initialState,
+      aboutSlice: {
+        ...initialState.aboutSlice,
+        isAdminMode: true,
+        editingSection: "familyHistory",
+      },
+    };
+    const editingStore = mockStore(editingState);
+
+    render(
+      <Provider store={editingStore}>
+        <About />
+      </Provider>
+    );
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/AboutEditModal.test.js
+++ b/src/__tests__/AboutEditModal.test.js
@@ -1,0 +1,184 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import { AboutEditModal } from "../components/aboutEditModal/AboutEditModal";
+
+const mockStore = configureStore([]);
+
+describe("AboutEditModal", () => {
+  const initialState = {
+    aboutSlice: {
+      familyHistory: {
+        id: 1,
+        title: "Our Heritage",
+        content: "Founded in 1952...",
+        imageUrl: null,
+      },
+      guides: [
+        {
+          id: 1,
+          name: "Jake Wilson",
+          role: "Head Guide",
+          bio: "Experienced guide",
+          yearsExperience: 25,
+          specialties: ["Elk"],
+          imageUrl: null,
+        },
+      ],
+      conservation: {
+        id: 1,
+        title: "Conservation",
+        content: "We care about conservation",
+        practices: ["Practice 1"],
+      },
+      ethics: {
+        id: 1,
+        title: "Ethics",
+        content: "We have strong ethics",
+        principles: ["Principle 1"],
+      },
+    },
+  };
+
+  let store;
+
+  beforeEach(() => {
+    store = mockStore(initialState);
+  });
+
+  it("should not render when show is false", () => {
+    render(
+      <Provider store={store}>
+        <AboutEditModal show={false} section={null} onHide={jest.fn()} />
+      </Provider>
+    );
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("should render when show is true with familyHistory section", () => {
+    render(
+      <Provider store={store}>
+        <AboutEditModal
+          show={true}
+          section="familyHistory"
+          onHide={jest.fn()}
+        />
+      </Provider>
+    );
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText(/edit family history/i)).toBeInTheDocument();
+  });
+
+  it("should render FamilyHistoryForm when section is familyHistory", () => {
+    render(
+      <Provider store={store}>
+        <AboutEditModal
+          show={true}
+          section="familyHistory"
+          onHide={jest.fn()}
+        />
+      </Provider>
+    );
+    expect(screen.getByLabelText(/title/i)).toHaveValue("Our Heritage");
+  });
+
+  it("should render GuideForm when section is guide with guideId", () => {
+    render(
+      <Provider store={store}>
+        <AboutEditModal
+          show={true}
+          section="guide"
+          guideId={1}
+          onHide={jest.fn()}
+        />
+      </Provider>
+    );
+    expect(screen.getByText(/edit guide/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^name$/i)).toHaveValue("Jake Wilson");
+  });
+
+  it("should render ConservationForm when section is conservation", () => {
+    render(
+      <Provider store={store}>
+        <AboutEditModal
+          show={true}
+          section="conservation"
+          onHide={jest.fn()}
+        />
+      </Provider>
+    );
+    expect(screen.getByText(/edit conservation/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/title/i)).toHaveValue("Conservation");
+  });
+
+  it("should render EthicsForm when section is ethics", () => {
+    render(
+      <Provider store={store}>
+        <AboutEditModal show={true} section="ethics" onHide={jest.fn()} />
+      </Provider>
+    );
+    expect(screen.getByText(/edit ethics/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/title/i)).toHaveValue("Ethics");
+  });
+
+  it("should call onHide when cancel is clicked", () => {
+    const mockOnHide = jest.fn();
+    render(
+      <Provider store={store}>
+        <AboutEditModal
+          show={true}
+          section="familyHistory"
+          onHide={mockOnHide}
+        />
+      </Provider>
+    );
+    const cancelButton = screen.getByText("Cancel");
+    fireEvent.click(cancelButton);
+    expect(mockOnHide).toHaveBeenCalled();
+  });
+
+  it("should dispatch action when save is clicked on familyHistory", () => {
+    render(
+      <Provider store={store}>
+        <AboutEditModal
+          show={true}
+          section="familyHistory"
+          onHide={jest.fn()}
+        />
+      </Provider>
+    );
+
+    const titleInput = screen.getByLabelText(/title/i);
+    fireEvent.change(titleInput, { target: { value: "New Title" } });
+
+    const saveButton = screen.getByText("Save");
+    fireEvent.click(saveButton);
+
+    const actions = store.getActions();
+    expect(actions.length).toBeGreaterThan(0);
+    expect(actions[0].type).toBe("about/setFamilyHistory");
+  });
+
+  it("should dispatch updateGuide action when save is clicked on guide", () => {
+    render(
+      <Provider store={store}>
+        <AboutEditModal
+          show={true}
+          section="guide"
+          guideId={1}
+          onHide={jest.fn()}
+        />
+      </Provider>
+    );
+
+    const nameInput = screen.getByLabelText(/^name$/i);
+    fireEvent.change(nameInput, { target: { value: "Updated Name" } });
+
+    const saveButton = screen.getByText("Save");
+    fireEvent.click(saveButton);
+
+    const actions = store.getActions();
+    expect(actions.length).toBeGreaterThan(0);
+    expect(actions[0].type).toBe("about/updateGuide");
+  });
+});

--- a/src/__tests__/AboutSlice.test.js
+++ b/src/__tests__/AboutSlice.test.js
@@ -1,0 +1,233 @@
+import aboutSlice, {
+  setFamilyHistory,
+  addGuide,
+  updateGuide,
+  deleteGuide,
+  setConservation,
+  setEthics,
+  toggleAdminMode,
+  setEditingSection,
+  clearEditingSection,
+} from "../slice/AboutSlice";
+
+describe("AboutSlice", () => {
+  const initialState = {
+    familyHistory: {
+      id: 1,
+      title: "Our Heritage",
+      content:
+        "Founded in 1952 by the Wilson family, Big Bucks Outfitters has been guiding hunters through Montana's pristine wilderness for over 70 years. What started as a small family operation has grown into a legacy of conservation, ethical hunting, and unforgettable outdoor experiences.",
+      imageUrl: null,
+    },
+    guides: [
+      {
+        id: 1,
+        name: "Jake Wilson",
+        role: "Head Guide & Owner",
+        bio: "Third-generation outfitter with 25 years of experience in Montana backcountry.",
+        yearsExperience: 25,
+        specialties: ["Elk", "Mule Deer", "Backcountry Navigation"],
+        imageUrl: null,
+      },
+      {
+        id: 2,
+        name: "Sarah Martinez",
+        role: "Senior Guide",
+        bio: "Wildlife biologist turned hunting guide, specializing in ethical harvesting and conservation education.",
+        yearsExperience: 15,
+        specialties: ["Whitetail", "Black Bear", "Wildlife Biology"],
+        imageUrl: null,
+      },
+      {
+        id: 3,
+        name: "Tom Blackwood",
+        role: "Lead Wilderness Guide",
+        bio: "Former search and rescue specialist with unmatched knowledge of Montana's wilderness terrain.",
+        yearsExperience: 18,
+        specialties: ["Mountain Hunting", "Safety & First Aid", "Wilderness Survival"],
+        imageUrl: null,
+      },
+    ],
+    conservation: {
+      id: 1,
+      title: "Conservation & Sustainability",
+      content:
+        "At Big Bucks Outfitters, we believe in giving back to the land that provides us with so much. Our commitment to conservation goes beyond compliance—it's a core value.",
+      practices: [
+        "Partner with Montana Fish, Wildlife & Parks for habitat restoration",
+        "Maintain sustainable harvest quotas below legal limits",
+        "Donate 10% of profits to local wildlife conservation organizations",
+        "Practice Leave No Trace principles on all guided hunts",
+        "Educate hunters on ethical shot placement and quick, humane kills",
+        "Support predator management programs for ecosystem balance",
+      ],
+    },
+    ethics: {
+      id: 1,
+      title: "Hunting Ethics & Philosophy",
+      content:
+        "We believe hunting is a privilege that comes with profound responsibility. Our philosophy centers on respect—for the animal, the land, and the tradition.",
+      principles: [
+        "Fair Chase: No baiting, no fenced hunts, no guaranteed kills",
+        "One Shot, One Kill: Emphasis on marksmanship and ethical shot selection",
+        "Full Utilization: Respect the harvest by using meat, hide, and antlers",
+        "Mentorship: Pass on traditions and ethics to the next generation",
+        "Conservation First: Hunters are the original conservationists",
+        "Safety Above All: No trophy is worth compromising safety",
+      ],
+    },
+    isAdminMode: false,
+    editingSection: null,
+  };
+
+  describe("initial state", () => {
+    it("should have correct initial state structure", () => {
+      const state = aboutSlice(undefined, { type: "@@INIT" });
+      expect(state).toHaveProperty("familyHistory");
+      expect(state).toHaveProperty("guides");
+      expect(state).toHaveProperty("conservation");
+      expect(state).toHaveProperty("ethics");
+      expect(state).toHaveProperty("isAdminMode");
+      expect(state).toHaveProperty("editingSection");
+    });
+
+    it("should initialize with 3 guides", () => {
+      const state = aboutSlice(undefined, { type: "@@INIT" });
+      expect(state.guides).toHaveLength(3);
+    });
+
+    it("should initialize with admin mode false", () => {
+      const state = aboutSlice(undefined, { type: "@@INIT" });
+      expect(state.isAdminMode).toBe(false);
+    });
+  });
+
+  describe("setFamilyHistory", () => {
+    it("should update family history content", () => {
+      const updates = { title: "New Title", content: "New content" };
+      const state = aboutSlice(initialState, setFamilyHistory(updates));
+      expect(state.familyHistory.title).toBe("New Title");
+      expect(state.familyHistory.content).toBe("New content");
+    });
+
+    it("should preserve id when updating", () => {
+      const updates = { title: "New Title" };
+      const state = aboutSlice(initialState, setFamilyHistory(updates));
+      expect(state.familyHistory.id).toBe(1);
+    });
+  });
+
+  describe("guide management", () => {
+    describe("addGuide", () => {
+      it("should add a new guide to the guides array", () => {
+        const newGuide = {
+          id: 4,
+          name: "Emily Chen",
+          role: "Guide",
+          bio: "New guide bio",
+          yearsExperience: 5,
+          specialties: ["Archery"],
+          imageUrl: null,
+        };
+        const state = aboutSlice(initialState, addGuide(newGuide));
+        expect(state.guides).toHaveLength(4);
+        expect(state.guides[3]).toEqual(newGuide);
+      });
+    });
+
+    describe("updateGuide", () => {
+      it("should update an existing guide", () => {
+        const updates = {
+          id: 1,
+          updates: { yearsExperience: 26, bio: "Updated bio" },
+        };
+        const state = aboutSlice(initialState, updateGuide(updates));
+        expect(state.guides[0].yearsExperience).toBe(26);
+        expect(state.guides[0].bio).toBe("Updated bio");
+        expect(state.guides[0].name).toBe("Jake Wilson");
+      });
+
+      it("should not modify other guides", () => {
+        const updates = { id: 1, updates: { name: "Updated Name" } };
+        const state = aboutSlice(initialState, updateGuide(updates));
+        expect(state.guides[1].name).toBe("Sarah Martinez");
+        expect(state.guides[2].name).toBe("Tom Blackwood");
+      });
+    });
+
+    describe("deleteGuide", () => {
+      it("should remove a guide by id", () => {
+        const state = aboutSlice(initialState, deleteGuide(2));
+        expect(state.guides).toHaveLength(2);
+        expect(state.guides.find((g) => g.id === 2)).toBeUndefined();
+      });
+
+      it("should keep other guides intact", () => {
+        const state = aboutSlice(initialState, deleteGuide(2));
+        expect(state.guides[0].id).toBe(1);
+        expect(state.guides[1].id).toBe(3);
+      });
+    });
+  });
+
+  describe("setConservation", () => {
+    it("should update conservation content", () => {
+      const updates = { title: "New Conservation Title" };
+      const state = aboutSlice(initialState, setConservation(updates));
+      expect(state.conservation.title).toBe("New Conservation Title");
+    });
+
+    it("should update conservation practices", () => {
+      const updates = { practices: ["Practice 1", "Practice 2"] };
+      const state = aboutSlice(initialState, setConservation(updates));
+      expect(state.conservation.practices).toEqual(["Practice 1", "Practice 2"]);
+    });
+  });
+
+  describe("setEthics", () => {
+    it("should update ethics content", () => {
+      const updates = { content: "New ethics content" };
+      const state = aboutSlice(initialState, setEthics(updates));
+      expect(state.ethics.content).toBe("New ethics content");
+    });
+
+    it("should update ethics principles", () => {
+      const updates = { principles: ["Principle 1"] };
+      const state = aboutSlice(initialState, setEthics(updates));
+      expect(state.ethics.principles).toEqual(["Principle 1"]);
+    });
+  });
+
+  describe("admin mode", () => {
+    describe("toggleAdminMode", () => {
+      it("should toggle admin mode from false to true", () => {
+        const state = aboutSlice(initialState, toggleAdminMode());
+        expect(state.isAdminMode).toBe(true);
+      });
+
+      it("should toggle admin mode from true to false", () => {
+        const adminState = { ...initialState, isAdminMode: true };
+        const state = aboutSlice(adminState, toggleAdminMode());
+        expect(state.isAdminMode).toBe(false);
+      });
+    });
+
+    describe("setEditingSection", () => {
+      it("should set the editing section", () => {
+        const state = aboutSlice(
+          initialState,
+          setEditingSection("familyHistory")
+        );
+        expect(state.editingSection).toBe("familyHistory");
+      });
+    });
+
+    describe("clearEditingSection", () => {
+      it("should clear the editing section", () => {
+        const editingState = { ...initialState, editingSection: "guides" };
+        const state = aboutSlice(editingState, clearEditingSection());
+        expect(state.editingSection).toBeNull();
+      });
+    });
+  });
+});

--- a/src/__tests__/ConservationForm.test.js
+++ b/src/__tests__/ConservationForm.test.js
@@ -1,0 +1,134 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ConservationForm } from "../components/aboutForms/ConservationForm";
+
+describe("ConservationForm", () => {
+  const mockData = {
+    id: 1,
+    title: "Conservation & Sustainability",
+    content: "We are committed to conservation.",
+    practices: ["Practice 1", "Practice 2"],
+  };
+
+  const mockOnSave = jest.fn();
+  const mockOnCancel = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should render form with initial data", () => {
+    render(
+      <ConservationForm
+        data={mockData}
+        onSave={mockOnSave}
+        onCancel={mockOnCancel}
+      />
+    );
+    expect(screen.getByLabelText(/title/i)).toHaveValue(
+      "Conservation & Sustainability"
+    );
+  });
+
+  it("should render existing practices", () => {
+    render(
+      <ConservationForm
+        data={mockData}
+        onSave={mockOnSave}
+        onCancel={mockOnCancel}
+      />
+    );
+    expect(screen.getByText("Practice 1")).toBeInTheDocument();
+    expect(screen.getByText("Practice 2")).toBeInTheDocument();
+  });
+
+  it("should add new practice when add button clicked", () => {
+    render(
+      <ConservationForm
+        data={mockData}
+        onSave={mockOnSave}
+        onCancel={mockOnCancel}
+      />
+    );
+
+    const input = screen.getByPlaceholderText(/add a practice/i);
+    const addButton = screen.getByText("Add");
+
+    fireEvent.change(input, { target: { value: "Practice 3" } });
+    fireEvent.click(addButton);
+
+    expect(screen.getByText("Practice 3")).toBeInTheDocument();
+  });
+
+  it("should not add empty practice", () => {
+    render(
+      <ConservationForm
+        data={mockData}
+        onSave={mockOnSave}
+        onCancel={mockOnCancel}
+      />
+    );
+
+    const addButton = screen.getByText("Add");
+    const practicesBefore = screen.getAllByRole("button", { name: /delete/i })
+      .length;
+
+    fireEvent.click(addButton);
+
+    const practicesAfter = screen.getAllByRole("button", { name: /delete/i })
+      .length;
+    expect(practicesAfter).toBe(practicesBefore);
+  });
+
+  it("should delete practice when delete button clicked", () => {
+    render(
+      <ConservationForm
+        data={mockData}
+        onSave={mockOnSave}
+        onCancel={mockOnCancel}
+      />
+    );
+
+    const deleteButtons = screen.getAllByText("Delete");
+    fireEvent.click(deleteButtons[0]);
+
+    expect(screen.queryByText("Practice 1")).not.toBeInTheDocument();
+    expect(screen.getByText("Practice 2")).toBeInTheDocument();
+  });
+
+  it("should call onSave with updated data including practices", () => {
+    render(
+      <ConservationForm
+        data={mockData}
+        onSave={mockOnSave}
+        onCancel={mockOnCancel}
+      />
+    );
+
+    const input = screen.getByPlaceholderText(/add a practice/i);
+    const addButton = screen.getByText("Add");
+
+    fireEvent.change(input, { target: { value: "Practice 3" } });
+    fireEvent.click(addButton);
+
+    const saveButton = screen.getByText("Save");
+    fireEvent.click(saveButton);
+
+    expect(mockOnSave).toHaveBeenCalledWith({
+      ...mockData,
+      practices: ["Practice 1", "Practice 2", "Practice 3"],
+    });
+  });
+
+  it("should call onCancel when cancel button clicked", () => {
+    render(
+      <ConservationForm
+        data={mockData}
+        onSave={mockOnSave}
+        onCancel={mockOnCancel}
+      />
+    );
+    const cancelButton = screen.getByText("Cancel");
+    fireEvent.click(cancelButton);
+    expect(mockOnCancel).toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/EditableSection.test.js
+++ b/src/__tests__/EditableSection.test.js
@@ -1,0 +1,100 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { EditableSection } from "../components/editableSection/EditableSection";
+
+describe("EditableSection", () => {
+  const mockSection = {
+    title: "Our Heritage",
+    content: "Founded in 1952 by the Wilson family...",
+  };
+
+  const mockSectionWithList = {
+    title: "Conservation Practices",
+    content: "We are committed to conservation.",
+    listItems: [
+      "Practice 1: Habitat restoration",
+      "Practice 2: Sustainable harvest",
+      "Practice 3: Donate to conservation",
+    ],
+  };
+
+  const mockOnEdit = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should render section title", () => {
+    render(<EditableSection section={mockSection} isAdminMode={false} />);
+    expect(screen.getByText("Our Heritage")).toBeInTheDocument();
+  });
+
+  it("should render section content", () => {
+    render(<EditableSection section={mockSection} isAdminMode={false} />);
+    expect(
+      screen.getByText(/Founded in 1952 by the Wilson family/)
+    ).toBeInTheDocument();
+  });
+
+  it("should render list items when provided", () => {
+    render(
+      <EditableSection section={mockSectionWithList} isAdminMode={false} />
+    );
+    expect(screen.getByText(/Practice 1: Habitat restoration/)).toBeInTheDocument();
+    expect(screen.getByText(/Practice 2: Sustainable harvest/)).toBeInTheDocument();
+    expect(screen.getByText(/Practice 3: Donate to conservation/)).toBeInTheDocument();
+  });
+
+  it("should not render list when listItems is not provided", () => {
+    const { container } = render(
+      <EditableSection section={mockSection} isAdminMode={false} />
+    );
+    expect(container.querySelector("ul")).not.toBeInTheDocument();
+  });
+
+  it("should not show edit button when not in admin mode", () => {
+    render(<EditableSection section={mockSection} isAdminMode={false} />);
+    expect(screen.queryByText("Edit")).not.toBeInTheDocument();
+  });
+
+  it("should show edit button when in admin mode", () => {
+    render(
+      <EditableSection
+        section={mockSection}
+        isAdminMode={true}
+        onEdit={mockOnEdit}
+      />
+    );
+    expect(screen.getByText("Edit")).toBeInTheDocument();
+  });
+
+  it("should call onEdit when edit button is clicked", () => {
+    render(
+      <EditableSection
+        section={mockSection}
+        isAdminMode={true}
+        onEdit={mockOnEdit}
+      />
+    );
+    const editButton = screen.getByText("Edit");
+    fireEvent.click(editButton);
+    expect(mockOnEdit).toHaveBeenCalled();
+  });
+
+  it("should render with Bootstrap Card structure", () => {
+    const { container } = render(
+      <EditableSection section={mockSection} isAdminMode={false} />
+    );
+    expect(container.querySelector(".card")).toBeInTheDocument();
+  });
+
+  it("should apply custom className if provided", () => {
+    const { container } = render(
+      <EditableSection
+        section={mockSection}
+        isAdminMode={false}
+        className="custom-class"
+      />
+    );
+    expect(container.querySelector(".custom-class")).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/EthicsForm.test.js
+++ b/src/__tests__/EthicsForm.test.js
@@ -1,0 +1,106 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { EthicsForm } from "../components/aboutForms/EthicsForm";
+
+describe("EthicsForm", () => {
+  const mockData = {
+    id: 1,
+    title: "Hunting Ethics & Philosophy",
+    content: "We believe in responsible hunting.",
+    principles: ["Principle 1", "Principle 2"],
+  };
+
+  const mockOnSave = jest.fn();
+  const mockOnCancel = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should render form with initial data", () => {
+    render(
+      <EthicsForm data={mockData} onSave={mockOnSave} onCancel={mockOnCancel} />
+    );
+    expect(screen.getByLabelText(/title/i)).toHaveValue(
+      "Hunting Ethics & Philosophy"
+    );
+  });
+
+  it("should render existing principles", () => {
+    render(
+      <EthicsForm data={mockData} onSave={mockOnSave} onCancel={mockOnCancel} />
+    );
+    expect(screen.getByText("Principle 1")).toBeInTheDocument();
+    expect(screen.getByText("Principle 2")).toBeInTheDocument();
+  });
+
+  it("should add new principle when add button clicked", () => {
+    render(
+      <EthicsForm data={mockData} onSave={mockOnSave} onCancel={mockOnCancel} />
+    );
+
+    const input = screen.getByPlaceholderText(/add a principle/i);
+    const addButton = screen.getByText("Add");
+
+    fireEvent.change(input, { target: { value: "Principle 3" } });
+    fireEvent.click(addButton);
+
+    expect(screen.getByText("Principle 3")).toBeInTheDocument();
+  });
+
+  it("should not add empty principle", () => {
+    render(
+      <EthicsForm data={mockData} onSave={mockOnSave} onCancel={mockOnCancel} />
+    );
+
+    const addButton = screen.getByText("Add");
+    const principlesBefore = screen.getAllByRole("button", { name: /delete/i })
+      .length;
+
+    fireEvent.click(addButton);
+
+    const principlesAfter = screen.getAllByRole("button", { name: /delete/i })
+      .length;
+    expect(principlesAfter).toBe(principlesBefore);
+  });
+
+  it("should delete principle when delete button clicked", () => {
+    render(
+      <EthicsForm data={mockData} onSave={mockOnSave} onCancel={mockOnCancel} />
+    );
+
+    const deleteButtons = screen.getAllByText("Delete");
+    fireEvent.click(deleteButtons[0]);
+
+    expect(screen.queryByText("Principle 1")).not.toBeInTheDocument();
+    expect(screen.getByText("Principle 2")).toBeInTheDocument();
+  });
+
+  it("should call onSave with updated data including principles", () => {
+    render(
+      <EthicsForm data={mockData} onSave={mockOnSave} onCancel={mockOnCancel} />
+    );
+
+    const input = screen.getByPlaceholderText(/add a principle/i);
+    const addButton = screen.getByText("Add");
+
+    fireEvent.change(input, { target: { value: "Principle 3" } });
+    fireEvent.click(addButton);
+
+    const saveButton = screen.getByText("Save");
+    fireEvent.click(saveButton);
+
+    expect(mockOnSave).toHaveBeenCalledWith({
+      ...mockData,
+      principles: ["Principle 1", "Principle 2", "Principle 3"],
+    });
+  });
+
+  it("should call onCancel when cancel button clicked", () => {
+    render(
+      <EthicsForm data={mockData} onSave={mockOnSave} onCancel={mockOnCancel} />
+    );
+    const cancelButton = screen.getByText("Cancel");
+    fireEvent.click(cancelButton);
+    expect(mockOnCancel).toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/FamilyHistoryForm.test.js
+++ b/src/__tests__/FamilyHistoryForm.test.js
@@ -1,0 +1,152 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { FamilyHistoryForm } from "../components/aboutForms/FamilyHistoryForm";
+
+describe("FamilyHistoryForm", () => {
+  const mockData = {
+    id: 1,
+    title: "Our Heritage",
+    content: "Founded in 1952...",
+    imageUrl: null,
+  };
+
+  const mockOnSave = jest.fn();
+  const mockOnCancel = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should render form with initial data", () => {
+    render(
+      <FamilyHistoryForm
+        data={mockData}
+        onSave={mockOnSave}
+        onCancel={mockOnCancel}
+      />
+    );
+    expect(screen.getByLabelText(/title/i)).toHaveValue("Our Heritage");
+    expect(screen.getByLabelText(/content/i)).toHaveValue("Founded in 1952...");
+  });
+
+  it("should render title input field", () => {
+    render(
+      <FamilyHistoryForm
+        data={mockData}
+        onSave={mockOnSave}
+        onCancel={mockOnCancel}
+      />
+    );
+    expect(screen.getByLabelText(/title/i)).toBeInTheDocument();
+  });
+
+  it("should render content textarea", () => {
+    render(
+      <FamilyHistoryForm
+        data={mockData}
+        onSave={mockOnSave}
+        onCancel={mockOnCancel}
+      />
+    );
+    expect(screen.getByLabelText(/content/i)).toBeInTheDocument();
+  });
+
+  it("should update title when user types", () => {
+    render(
+      <FamilyHistoryForm
+        data={mockData}
+        onSave={mockOnSave}
+        onCancel={mockOnCancel}
+      />
+    );
+    const titleInput = screen.getByLabelText(/title/i);
+    fireEvent.change(titleInput, { target: { value: "New Title" } });
+    expect(titleInput).toHaveValue("New Title");
+  });
+
+  it("should update content when user types", () => {
+    render(
+      <FamilyHistoryForm
+        data={mockData}
+        onSave={mockOnSave}
+        onCancel={mockOnCancel}
+      />
+    );
+    const contentTextarea = screen.getByLabelText(/content/i);
+    fireEvent.change(contentTextarea, { target: { value: "New content" } });
+    expect(contentTextarea).toHaveValue("New content");
+  });
+
+  it("should call onSave with updated data when save button clicked", () => {
+    render(
+      <FamilyHistoryForm
+        data={mockData}
+        onSave={mockOnSave}
+        onCancel={mockOnCancel}
+      />
+    );
+
+    const titleInput = screen.getByLabelText(/title/i);
+    const contentTextarea = screen.getByLabelText(/content/i);
+
+    fireEvent.change(titleInput, { target: { value: "Updated Title" } });
+    fireEvent.change(contentTextarea, { target: { value: "Updated content" } });
+
+    const saveButton = screen.getByText("Save");
+    fireEvent.click(saveButton);
+
+    expect(mockOnSave).toHaveBeenCalledWith({
+      ...mockData,
+      title: "Updated Title",
+      content: "Updated content",
+    });
+  });
+
+  it("should call onCancel when cancel button clicked", () => {
+    render(
+      <FamilyHistoryForm
+        data={mockData}
+        onSave={mockOnSave}
+        onCancel={mockOnCancel}
+      />
+    );
+    const cancelButton = screen.getByText("Cancel");
+    fireEvent.click(cancelButton);
+    expect(mockOnCancel).toHaveBeenCalled();
+  });
+
+  it("should not call onSave if title is empty", () => {
+    render(
+      <FamilyHistoryForm
+        data={mockData}
+        onSave={mockOnSave}
+        onCancel={mockOnCancel}
+      />
+    );
+
+    const titleInput = screen.getByLabelText(/title/i);
+    fireEvent.change(titleInput, { target: { value: "" } });
+
+    const saveButton = screen.getByText("Save");
+    fireEvent.click(saveButton);
+
+    expect(mockOnSave).not.toHaveBeenCalled();
+  });
+
+  it("should show validation error when title is empty", () => {
+    render(
+      <FamilyHistoryForm
+        data={mockData}
+        onSave={mockOnSave}
+        onCancel={mockOnCancel}
+      />
+    );
+
+    const titleInput = screen.getByLabelText(/title/i);
+    fireEvent.change(titleInput, { target: { value: "" } });
+
+    const saveButton = screen.getByText("Save");
+    fireEvent.click(saveButton);
+
+    expect(screen.getByText(/title is required/i)).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/GuideCard.test.js
+++ b/src/__tests__/GuideCard.test.js
@@ -1,0 +1,139 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { GuideCard } from "../components/guideCard/GuideCard";
+
+describe("GuideCard", () => {
+  const mockGuide = {
+    id: 1,
+    name: "Jake Wilson",
+    role: "Head Guide & Owner",
+    bio: "Third-generation outfitter with 25 years of experience in Montana backcountry.",
+    yearsExperience: 25,
+    specialties: ["Elk", "Mule Deer", "Backcountry Navigation"],
+    imageUrl: null,
+  };
+
+  const mockOnEdit = jest.fn();
+  const mockOnDelete = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should render guide name", () => {
+    render(<GuideCard guide={mockGuide} isAdminMode={false} />);
+    expect(screen.getByText("Jake Wilson")).toBeInTheDocument();
+  });
+
+  it("should render guide role", () => {
+    render(<GuideCard guide={mockGuide} isAdminMode={false} />);
+    expect(screen.getByText("Head Guide & Owner")).toBeInTheDocument();
+  });
+
+  it("should render guide bio", () => {
+    render(<GuideCard guide={mockGuide} isAdminMode={false} />);
+    expect(
+      screen.getByText(/Third-generation outfitter with 25 years/)
+    ).toBeInTheDocument();
+  });
+
+  it("should render years of experience", () => {
+    render(<GuideCard guide={mockGuide} isAdminMode={false} />);
+    expect(screen.getByText(/25 years experience/i)).toBeInTheDocument();
+  });
+
+  it("should render all specialties", () => {
+    render(<GuideCard guide={mockGuide} isAdminMode={false} />);
+    expect(screen.getByText("Elk")).toBeInTheDocument();
+    expect(screen.getByText("Mule Deer")).toBeInTheDocument();
+    expect(screen.getByText("Backcountry Navigation")).toBeInTheDocument();
+  });
+
+  it("should render placeholder image when imageUrl is null", () => {
+    const { container } = render(
+      <GuideCard guide={mockGuide} isAdminMode={false} />
+    );
+    const placeholder = container.querySelector(".guide-placeholder");
+    expect(placeholder).toBeInTheDocument();
+  });
+
+  it("should display guide initials in placeholder", () => {
+    const { container } = render(
+      <GuideCard guide={mockGuide} isAdminMode={false} />
+    );
+    const placeholder = container.querySelector(".guide-placeholder");
+    expect(placeholder).toHaveTextContent("JW");
+  });
+
+  it("should render actual image when imageUrl is provided", () => {
+    const guideWithImage = { ...mockGuide, imageUrl: "/images/jake.jpg" };
+    render(<GuideCard guide={guideWithImage} isAdminMode={false} />);
+    const img = screen.getByAltText("Jake Wilson");
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute("src", "/images/jake.jpg");
+  });
+
+  it("should not show edit and delete buttons when not in admin mode", () => {
+    render(<GuideCard guide={mockGuide} isAdminMode={false} />);
+    expect(screen.queryByText("Edit")).not.toBeInTheDocument();
+    expect(screen.queryByText("Delete")).not.toBeInTheDocument();
+  });
+
+  it("should show edit button when in admin mode", () => {
+    render(
+      <GuideCard
+        guide={mockGuide}
+        isAdminMode={true}
+        onEdit={mockOnEdit}
+        onDelete={mockOnDelete}
+      />
+    );
+    expect(screen.getByText("Edit")).toBeInTheDocument();
+  });
+
+  it("should show delete button when in admin mode", () => {
+    render(
+      <GuideCard
+        guide={mockGuide}
+        isAdminMode={true}
+        onEdit={mockOnEdit}
+        onDelete={mockOnDelete}
+      />
+    );
+    expect(screen.getByText("Delete")).toBeInTheDocument();
+  });
+
+  it("should call onEdit with guide id when edit button is clicked", () => {
+    render(
+      <GuideCard
+        guide={mockGuide}
+        isAdminMode={true}
+        onEdit={mockOnEdit}
+        onDelete={mockOnDelete}
+      />
+    );
+    const editButton = screen.getByText("Edit");
+    fireEvent.click(editButton);
+    expect(mockOnEdit).toHaveBeenCalledWith(1);
+  });
+
+  it("should call onDelete with guide id when delete button is clicked", () => {
+    render(
+      <GuideCard
+        guide={mockGuide}
+        isAdminMode={true}
+        onEdit={mockOnEdit}
+        onDelete={mockOnDelete}
+      />
+    );
+    const deleteButton = screen.getByText("Delete");
+    fireEvent.click(deleteButton);
+    expect(mockOnDelete).toHaveBeenCalledWith(1);
+  });
+
+  it("should render with Bootstrap Card structure", () => {
+    const { container } = render(
+      <GuideCard guide={mockGuide} isAdminMode={false} />
+    );
+    expect(container.querySelector(".card")).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/GuideForm.test.js
+++ b/src/__tests__/GuideForm.test.js
@@ -1,0 +1,147 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { GuideForm } from "../components/aboutForms/GuideForm";
+
+describe("GuideForm", () => {
+  const mockGuide = {
+    id: 1,
+    name: "Jake Wilson",
+    role: "Head Guide & Owner",
+    bio: "Third-generation outfitter",
+    yearsExperience: 25,
+    specialties: ["Elk", "Deer"],
+    imageUrl: null,
+  };
+
+  const mockOnSave = jest.fn();
+  const mockOnCancel = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should render form with initial data", () => {
+    render(
+      <GuideForm data={mockGuide} onSave={mockOnSave} onCancel={mockOnCancel} />
+    );
+    expect(screen.getByLabelText(/^name$/i)).toHaveValue("Jake Wilson");
+    expect(screen.getByLabelText(/role/i)).toHaveValue("Head Guide & Owner");
+    expect(screen.getByLabelText(/bio/i)).toHaveValue("Third-generation outfitter");
+    expect(screen.getByLabelText(/years of experience/i)).toHaveValue(25);
+  });
+
+  it("should render all form fields", () => {
+    render(
+      <GuideForm data={mockGuide} onSave={mockOnSave} onCancel={mockOnCancel} />
+    );
+    expect(screen.getByLabelText(/^name$/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/role/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/bio/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/years of experience/i)).toBeInTheDocument();
+  });
+
+  it("should render existing specialties", () => {
+    render(
+      <GuideForm data={mockGuide} onSave={mockOnSave} onCancel={mockOnCancel} />
+    );
+    expect(screen.getByText("Elk")).toBeInTheDocument();
+    expect(screen.getByText("Deer")).toBeInTheDocument();
+  });
+
+  it("should update name when user types", () => {
+    render(
+      <GuideForm data={mockGuide} onSave={mockOnSave} onCancel={mockOnCancel} />
+    );
+    const nameInput = screen.getByLabelText(/^name$/i);
+    fireEvent.change(nameInput, { target: { value: "New Name" } });
+    expect(nameInput).toHaveValue("New Name");
+  });
+
+  it("should update years of experience when user types", () => {
+    render(
+      <GuideForm data={mockGuide} onSave={mockOnSave} onCancel={mockOnCancel} />
+    );
+    const experienceInput = screen.getByLabelText(/years of experience/i);
+    fireEvent.change(experienceInput, { target: { value: "30" } });
+    expect(experienceInput).toHaveValue(30);
+  });
+
+  it("should add new specialty when add button clicked", () => {
+    render(
+      <GuideForm data={mockGuide} onSave={mockOnSave} onCancel={mockOnCancel} />
+    );
+
+    const input = screen.getByPlaceholderText(/add a specialty/i);
+    const addButton = screen.getByText("Add");
+
+    fireEvent.change(input, { target: { value: "Bear" } });
+    fireEvent.click(addButton);
+
+    expect(screen.getByText("Bear")).toBeInTheDocument();
+  });
+
+  it("should delete specialty when delete button clicked", () => {
+    render(
+      <GuideForm data={mockGuide} onSave={mockOnSave} onCancel={mockOnCancel} />
+    );
+
+    const deleteButtons = screen.getAllByText("Delete");
+    fireEvent.click(deleteButtons[0]);
+
+    expect(screen.queryByText("Elk")).not.toBeInTheDocument();
+    expect(screen.getByText("Deer")).toBeInTheDocument();
+  });
+
+  it("should not call onSave if name is empty", () => {
+    render(
+      <GuideForm data={mockGuide} onSave={mockOnSave} onCancel={mockOnCancel} />
+    );
+
+    const nameInput = screen.getByLabelText(/^name$/i);
+    fireEvent.change(nameInput, { target: { value: "" } });
+
+    const saveButton = screen.getByText("Save");
+    fireEvent.click(saveButton);
+
+    expect(mockOnSave).not.toHaveBeenCalled();
+  });
+
+  it("should show validation error when name is empty", () => {
+    render(
+      <GuideForm data={mockGuide} onSave={mockOnSave} onCancel={mockOnCancel} />
+    );
+
+    const nameInput = screen.getByLabelText(/^name$/i);
+    fireEvent.change(nameInput, { target: { value: "" } });
+
+    const saveButton = screen.getByText("Save");
+    fireEvent.click(saveButton);
+
+    expect(screen.getByText(/name is required/i)).toBeInTheDocument();
+  });
+
+  it("should call onSave with updated data when save button clicked", () => {
+    render(
+      <GuideForm data={mockGuide} onSave={mockOnSave} onCancel={mockOnCancel} />
+    );
+
+    const nameInput = screen.getByLabelText(/^name$/i);
+    fireEvent.change(nameInput, { target: { value: "Updated Name" } });
+
+    const saveButton = screen.getByText("Save");
+    fireEvent.click(saveButton);
+
+    expect(mockOnSave).toHaveBeenCalledWith({
+      ...mockGuide,
+      name: "Updated Name",
+    });
+  });
+
+  it("should call onCancel when cancel button clicked", () => {
+    render(
+      <GuideForm data={mockGuide} onSave={mockOnSave} onCancel={mockOnCancel} />
+    );
+    const cancelButton = screen.getByText("Cancel");
+    fireEvent.click(cancelButton);
+    expect(mockOnCancel).toHaveBeenCalled();
+  });
+});

--- a/src/components/aboutEditModal/AboutEditModal.js
+++ b/src/components/aboutEditModal/AboutEditModal.js
@@ -1,0 +1,95 @@
+import { Modal } from "react-bootstrap";
+import { useSelector, useDispatch } from "react-redux";
+import {
+  setFamilyHistory,
+  updateGuide,
+  setConservation,
+  setEthics,
+} from "../../slice/AboutSlice";
+import { FamilyHistoryForm } from "../aboutForms/FamilyHistoryForm";
+import { GuideForm } from "../aboutForms/GuideForm";
+import { ConservationForm } from "../aboutForms/ConservationForm";
+import { EthicsForm } from "../aboutForms/EthicsForm";
+import "./aboutEditModal.css";
+
+export function AboutEditModal({ show, section, guideId, onHide }) {
+  const dispatch = useDispatch();
+  const { familyHistory, guides, conservation, ethics } = useSelector(
+    (state) => state.aboutSlice
+  );
+
+  const handleSave = (data) => {
+    switch (section) {
+      case "familyHistory":
+        dispatch(setFamilyHistory(data));
+        break;
+      case "guide":
+        dispatch(updateGuide({ id: guideId, updates: data }));
+        break;
+      case "conservation":
+        dispatch(setConservation(data));
+        break;
+      case "ethics":
+        dispatch(setEthics(data));
+        break;
+      default:
+        break;
+    }
+    onHide();
+  };
+
+  const getModalTitle = () => {
+    switch (section) {
+      case "familyHistory":
+        return "Edit Family History";
+      case "guide":
+        return "Edit Guide";
+      case "conservation":
+        return "Edit Conservation";
+      case "ethics":
+        return "Edit Ethics";
+      default:
+        return "Edit";
+    }
+  };
+
+  const renderForm = () => {
+    switch (section) {
+      case "familyHistory":
+        return (
+          <FamilyHistoryForm
+            data={familyHistory}
+            onSave={handleSave}
+            onCancel={onHide}
+          />
+        );
+      case "guide":
+        const guide = guides.find((g) => g.id === guideId);
+        if (!guide) return null;
+        return <GuideForm data={guide} onSave={handleSave} onCancel={onHide} />;
+      case "conservation":
+        return (
+          <ConservationForm
+            data={conservation}
+            onSave={handleSave}
+            onCancel={onHide}
+          />
+        );
+      case "ethics":
+        return (
+          <EthicsForm data={ethics} onSave={handleSave} onCancel={onHide} />
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <Modal show={show} onHide={onHide} size="lg" centered>
+      <Modal.Header closeButton>
+        <Modal.Title>{getModalTitle()}</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>{renderForm()}</Modal.Body>
+    </Modal>
+  );
+}

--- a/src/components/aboutEditModal/aboutEditModal.css
+++ b/src/components/aboutEditModal/aboutEditModal.css
@@ -1,0 +1,14 @@
+.about-edit-modal .modal-body {
+  padding: 2rem;
+}
+
+.about-edit-modal .modal-title {
+  font-weight: bold;
+  color: #333;
+}
+
+@media (max-width: 576px) {
+  .about-edit-modal .modal-body {
+    padding: 1rem;
+  }
+}

--- a/src/components/aboutForms/ConservationForm.js
+++ b/src/components/aboutForms/ConservationForm.js
@@ -1,0 +1,120 @@
+import { useState } from "react";
+import { Form, Button, Alert } from "react-bootstrap";
+import "./aboutForms.css";
+
+export function ConservationForm({ data, onSave, onCancel }) {
+  const [formData, setFormData] = useState(data);
+  const [newPractice, setNewPractice] = useState("");
+  const [error, setError] = useState("");
+
+  const handleChange = (field, value) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+    if (error) setError("");
+  };
+
+  const handleAddPractice = () => {
+    if (newPractice.trim() === "") return;
+
+    setFormData((prev) => ({
+      ...prev,
+      practices: [...prev.practices, newPractice.trim()],
+    }));
+    setNewPractice("");
+  };
+
+  const handleDeletePractice = (index) => {
+    setFormData((prev) => ({
+      ...prev,
+      practices: prev.practices.filter((_, i) => i !== index),
+    }));
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+
+    if (!formData.title || formData.title.trim() === "") {
+      setError("Title is required");
+      return;
+    }
+
+    onSave(formData);
+  };
+
+  return (
+    <Form onSubmit={handleSubmit} className="about-form">
+      {error && <Alert variant="danger">{error}</Alert>}
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="title">Title</Form.Label>
+        <Form.Control
+          id="title"
+          type="text"
+          value={formData.title}
+          onChange={(e) => handleChange("title", e.target.value)}
+          placeholder="Enter section title"
+        />
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="content">Content</Form.Label>
+        <Form.Control
+          id="content"
+          as="textarea"
+          rows={4}
+          value={formData.content}
+          onChange={(e) => handleChange("content", e.target.value)}
+          placeholder="Enter section content"
+        />
+      </Form.Group>
+
+      <div className="list-input-group">
+        <Form.Label>Conservation Practices</Form.Label>
+        <div className="list-items-container">
+          {formData.practices.map((practice, index) => (
+            <div key={index} className="list-item-row">
+              <span className="list-item-text">{practice}</span>
+              <Button
+                variant="outline-danger"
+                size="sm"
+                onClick={() => handleDeletePractice(index)}
+                className="list-item-delete-btn"
+              >
+                Delete
+              </Button>
+            </div>
+          ))}
+          {formData.practices.length === 0 && (
+            <p className="text-muted">No practices added yet.</p>
+          )}
+        </div>
+
+        <div className="add-item-row">
+          <Form.Control
+            type="text"
+            value={newPractice}
+            onChange={(e) => setNewPractice(e.target.value)}
+            placeholder="Add a practice"
+            onKeyPress={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                handleAddPractice();
+              }
+            }}
+          />
+          <Button variant="success" onClick={handleAddPractice}>
+            Add
+          </Button>
+        </div>
+      </div>
+
+      <div className="form-actions">
+        <Button variant="secondary" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button variant="primary" type="submit">
+          Save
+        </Button>
+      </div>
+    </Form>
+  );
+}

--- a/src/components/aboutForms/EthicsForm.js
+++ b/src/components/aboutForms/EthicsForm.js
@@ -1,0 +1,120 @@
+import { useState } from "react";
+import { Form, Button, Alert } from "react-bootstrap";
+import "./aboutForms.css";
+
+export function EthicsForm({ data, onSave, onCancel }) {
+  const [formData, setFormData] = useState(data);
+  const [newPrinciple, setNewPrinciple] = useState("");
+  const [error, setError] = useState("");
+
+  const handleChange = (field, value) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+    if (error) setError("");
+  };
+
+  const handleAddPrinciple = () => {
+    if (newPrinciple.trim() === "") return;
+
+    setFormData((prev) => ({
+      ...prev,
+      principles: [...prev.principles, newPrinciple.trim()],
+    }));
+    setNewPrinciple("");
+  };
+
+  const handleDeletePrinciple = (index) => {
+    setFormData((prev) => ({
+      ...prev,
+      principles: prev.principles.filter((_, i) => i !== index),
+    }));
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+
+    if (!formData.title || formData.title.trim() === "") {
+      setError("Title is required");
+      return;
+    }
+
+    onSave(formData);
+  };
+
+  return (
+    <Form onSubmit={handleSubmit} className="about-form">
+      {error && <Alert variant="danger">{error}</Alert>}
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="title">Title</Form.Label>
+        <Form.Control
+          id="title"
+          type="text"
+          value={formData.title}
+          onChange={(e) => handleChange("title", e.target.value)}
+          placeholder="Enter section title"
+        />
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="content">Content</Form.Label>
+        <Form.Control
+          id="content"
+          as="textarea"
+          rows={4}
+          value={formData.content}
+          onChange={(e) => handleChange("content", e.target.value)}
+          placeholder="Enter section content"
+        />
+      </Form.Group>
+
+      <div className="list-input-group">
+        <Form.Label>Ethical Principles</Form.Label>
+        <div className="list-items-container">
+          {formData.principles.map((principle, index) => (
+            <div key={index} className="list-item-row">
+              <span className="list-item-text">{principle}</span>
+              <Button
+                variant="outline-danger"
+                size="sm"
+                onClick={() => handleDeletePrinciple(index)}
+                className="list-item-delete-btn"
+              >
+                Delete
+              </Button>
+            </div>
+          ))}
+          {formData.principles.length === 0 && (
+            <p className="text-muted">No principles added yet.</p>
+          )}
+        </div>
+
+        <div className="add-item-row">
+          <Form.Control
+            type="text"
+            value={newPrinciple}
+            onChange={(e) => setNewPrinciple(e.target.value)}
+            placeholder="Add a principle"
+            onKeyPress={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                handleAddPrinciple();
+              }
+            }}
+          />
+          <Button variant="success" onClick={handleAddPrinciple}>
+            Add
+          </Button>
+        </div>
+      </div>
+
+      <div className="form-actions">
+        <Button variant="secondary" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button variant="primary" type="submit">
+          Save
+        </Button>
+      </div>
+    </Form>
+  );
+}

--- a/src/components/aboutForms/FamilyHistoryForm.js
+++ b/src/components/aboutForms/FamilyHistoryForm.js
@@ -1,0 +1,62 @@
+import { useState } from "react";
+import { Form, Button, Alert } from "react-bootstrap";
+import "./aboutForms.css";
+
+export function FamilyHistoryForm({ data, onSave, onCancel }) {
+  const [formData, setFormData] = useState(data);
+  const [error, setError] = useState("");
+
+  const handleChange = (field, value) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+    if (error) setError("");
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+
+    if (!formData.title || formData.title.trim() === "") {
+      setError("Title is required");
+      return;
+    }
+
+    onSave(formData);
+  };
+
+  return (
+    <Form onSubmit={handleSubmit} className="about-form">
+      {error && <Alert variant="danger">{error}</Alert>}
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="title">Title</Form.Label>
+        <Form.Control
+          id="title"
+          type="text"
+          value={formData.title}
+          onChange={(e) => handleChange("title", e.target.value)}
+          placeholder="Enter section title"
+        />
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="content">Content</Form.Label>
+        <Form.Control
+          id="content"
+          as="textarea"
+          rows={6}
+          value={formData.content}
+          onChange={(e) => handleChange("content", e.target.value)}
+          placeholder="Enter section content"
+        />
+      </Form.Group>
+
+      <div className="form-actions">
+        <Button variant="secondary" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button variant="primary" type="submit">
+          Save
+        </Button>
+      </div>
+    </Form>
+  );
+}

--- a/src/components/aboutForms/GuideForm.js
+++ b/src/components/aboutForms/GuideForm.js
@@ -1,0 +1,155 @@
+import { useState } from "react";
+import { Form, Button, Alert, Row, Col } from "react-bootstrap";
+import "./aboutForms.css";
+
+export function GuideForm({ data, onSave, onCancel }) {
+  const [formData, setFormData] = useState(data);
+  const [newSpecialty, setNewSpecialty] = useState("");
+  const [error, setError] = useState("");
+
+  const handleChange = (field, value) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+    if (error) setError("");
+  };
+
+  const handleAddSpecialty = () => {
+    if (newSpecialty.trim() === "") return;
+
+    setFormData((prev) => ({
+      ...prev,
+      specialties: [...prev.specialties, newSpecialty.trim()],
+    }));
+    setNewSpecialty("");
+  };
+
+  const handleDeleteSpecialty = (index) => {
+    setFormData((prev) => ({
+      ...prev,
+      specialties: prev.specialties.filter((_, i) => i !== index),
+    }));
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+
+    if (!formData.name || formData.name.trim() === "") {
+      setError("Name is required");
+      return;
+    }
+
+    if (!formData.role || formData.role.trim() === "") {
+      setError("Role is required");
+      return;
+    }
+
+    onSave(formData);
+  };
+
+  return (
+    <Form onSubmit={handleSubmit} className="about-form">
+      {error && <Alert variant="danger">{error}</Alert>}
+
+      <Row>
+        <Col md={6}>
+          <Form.Group className="mb-3">
+            <Form.Label htmlFor="name">Name</Form.Label>
+            <Form.Control
+              id="name"
+              type="text"
+              value={formData.name}
+              onChange={(e) => handleChange("name", e.target.value)}
+              placeholder="Enter guide name"
+            />
+          </Form.Group>
+        </Col>
+        <Col md={6}>
+          <Form.Group className="mb-3">
+            <Form.Label htmlFor="role">Role</Form.Label>
+            <Form.Control
+              id="role"
+              type="text"
+              value={formData.role}
+              onChange={(e) => handleChange("role", e.target.value)}
+              placeholder="Enter guide role"
+            />
+          </Form.Group>
+        </Col>
+      </Row>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="bio">Bio</Form.Label>
+        <Form.Control
+          id="bio"
+          as="textarea"
+          rows={3}
+          value={formData.bio}
+          onChange={(e) => handleChange("bio", e.target.value)}
+          placeholder="Enter guide bio"
+        />
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="yearsExperience">Years of Experience</Form.Label>
+        <Form.Control
+          id="yearsExperience"
+          type="number"
+          value={formData.yearsExperience}
+          onChange={(e) =>
+            handleChange("yearsExperience", parseInt(e.target.value) || 0)
+          }
+          min="0"
+          max="99"
+        />
+      </Form.Group>
+
+      <div className="list-input-group">
+        <Form.Label>Specialties</Form.Label>
+        <div className="list-items-container">
+          {formData.specialties.map((specialty, index) => (
+            <div key={index} className="list-item-row">
+              <span className="list-item-text">{specialty}</span>
+              <Button
+                variant="outline-danger"
+                size="sm"
+                onClick={() => handleDeleteSpecialty(index)}
+                className="list-item-delete-btn"
+              >
+                Delete
+              </Button>
+            </div>
+          ))}
+          {formData.specialties.length === 0 && (
+            <p className="text-muted">No specialties added yet.</p>
+          )}
+        </div>
+
+        <div className="add-item-row">
+          <Form.Control
+            type="text"
+            value={newSpecialty}
+            onChange={(e) => setNewSpecialty(e.target.value)}
+            placeholder="Add a specialty"
+            onKeyPress={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                handleAddSpecialty();
+              }
+            }}
+          />
+          <Button variant="success" onClick={handleAddSpecialty}>
+            Add
+          </Button>
+        </div>
+      </div>
+
+      <div className="form-actions">
+        <Button variant="secondary" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button variant="primary" type="submit">
+          Save
+        </Button>
+      </div>
+    </Form>
+  );
+}

--- a/src/components/aboutForms/aboutForms.css
+++ b/src/components/aboutForms/aboutForms.css
@@ -1,0 +1,72 @@
+.about-form {
+  padding: 1rem 0;
+}
+
+.about-form .form-actions {
+  display: flex;
+  gap: 1rem;
+  justify-content: flex-end;
+  margin-top: 1.5rem;
+}
+
+.about-form .form-actions button {
+  min-width: 100px;
+}
+
+.list-input-group {
+  margin-bottom: 1rem;
+}
+
+.list-items-container {
+  border: 1px solid #dee2e6;
+  border-radius: 0.25rem;
+  padding: 1rem;
+  margin-bottom: 1rem;
+  min-height: 100px;
+}
+
+.list-item-row {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-bottom: 0.5rem;
+  padding: 0.5rem;
+  background-color: #f8f9fa;
+  border-radius: 0.25rem;
+}
+
+.list-item-text {
+  flex: 1;
+  word-break: break-word;
+}
+
+.list-item-delete-btn {
+  flex-shrink: 0;
+}
+
+.add-item-row {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.add-item-row input {
+  flex: 1;
+}
+
+@media (max-width: 576px) {
+  .about-form .form-actions {
+    flex-direction: column-reverse;
+  }
+
+  .about-form .form-actions button {
+    width: 100%;
+  }
+
+  .add-item-row {
+    flex-direction: column;
+  }
+
+  .add-item-row button {
+    width: 100%;
+  }
+}

--- a/src/components/editableSection/EditableSection.js
+++ b/src/components/editableSection/EditableSection.js
@@ -1,0 +1,38 @@
+import { Card, Button } from "react-bootstrap";
+import "./editableSection.css";
+
+export function EditableSection({
+  section,
+  isAdminMode,
+  onEdit,
+  className = "",
+}) {
+  const { title, content, listItems } = section;
+
+  return (
+    <Card className={`editable-section ${className}`}>
+      <Card.Body>
+        <div className="section-header">
+          <h2 className="section-title">{title}</h2>
+          {isAdminMode && onEdit && (
+            <Button variant="outline-primary" size="sm" onClick={onEdit}>
+              Edit
+            </Button>
+          )}
+        </div>
+
+        <p className="section-content">{content}</p>
+
+        {listItems && listItems.length > 0 && (
+          <ul className="section-list">
+            {listItems.map((item, index) => (
+              <li key={index} className="section-list-item">
+                {item}
+              </li>
+            ))}
+          </ul>
+        )}
+      </Card.Body>
+    </Card>
+  );
+}

--- a/src/components/editableSection/editableSection.css
+++ b/src/components/editableSection/editableSection.css
@@ -1,0 +1,67 @@
+.editable-section {
+  margin-bottom: 2rem;
+  border: none;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.5rem;
+}
+
+.section-title {
+  font-size: 2rem;
+  font-weight: bold;
+  color: #333;
+  margin: 0;
+}
+
+.section-content {
+  font-size: 1.1rem;
+  line-height: 1.8;
+  color: #555;
+  margin-bottom: 1.5rem;
+}
+
+.section-list {
+  list-style: none;
+  padding-left: 0;
+  margin: 0;
+}
+
+.section-list-item {
+  padding: 0.75rem 0;
+  padding-left: 2rem;
+  position: relative;
+  font-size: 1rem;
+  color: #555;
+  line-height: 1.6;
+}
+
+.section-list-item::before {
+  content: "✓";
+  position: absolute;
+  left: 0;
+  color: #ff8800;
+  font-weight: bold;
+  font-size: 1.2rem;
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+  .section-title {
+    font-size: 1.5rem;
+  }
+
+  .section-content {
+    font-size: 1rem;
+  }
+
+  .section-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+}

--- a/src/components/guideCard/GuideCard.js
+++ b/src/components/guideCard/GuideCard.js
@@ -1,0 +1,76 @@
+import { Card, Badge, Button, ButtonGroup } from "react-bootstrap";
+import "./guideCard.css";
+
+export function GuideCard({ guide, isAdminMode, onEdit, onDelete }) {
+  const { id, name, role, bio, yearsExperience, specialties, imageUrl } = guide;
+
+  const getInitials = (fullName) => {
+    const names = fullName.split(" ");
+    if (names.length >= 2) {
+      return `${names[0][0]}${names[names.length - 1][0]}`.toUpperCase();
+    }
+    return fullName.substring(0, 2).toUpperCase();
+  };
+
+  return (
+    <Card className="guide-card">
+      <Card.Body className="guide-card-body">
+        <div className="guide-image-section">
+          {imageUrl ? (
+            <img src={imageUrl} alt={name} className="guide-image" />
+          ) : (
+            <div className="guide-placeholder">
+              <span className="guide-initials">{getInitials(name)}</span>
+            </div>
+          )}
+        </div>
+
+        <div className="guide-info-section">
+          <div className="guide-header">
+            <div>
+              <h3 className="guide-name">{name}</h3>
+              <p className="guide-role">{role}</p>
+            </div>
+            <Badge bg="info" className="experience-badge">
+              {yearsExperience} years experience
+            </Badge>
+          </div>
+
+          <p className="guide-bio">{bio}</p>
+
+          <div className="guide-specialties">
+            <h4 className="specialties-title">Specialties:</h4>
+            <div className="specialties-list">
+              {specialties.map((specialty, index) => (
+                <Badge key={index} bg="secondary" className="specialty-badge">
+                  {specialty}
+                </Badge>
+              ))}
+            </div>
+          </div>
+
+          {isAdminMode && (
+            <div className="guide-admin-actions">
+              <ButtonGroup>
+                <Button
+                  variant="outline-primary"
+                  size="sm"
+                  onClick={() => onEdit(id)}
+                >
+                  Edit
+                </Button>
+                <Button
+                  variant="outline-danger"
+                  size="sm"
+                  onClick={() => onDelete(id)}
+                >
+                  Delete
+                </Button>
+              </ButtonGroup>
+            </div>
+          )}
+        </div>
+      </Card.Body>
+    </Card>
+  );
+}

--- a/src/components/guideCard/guideCard.css
+++ b/src/components/guideCard/guideCard.css
@@ -1,0 +1,154 @@
+.guide-card {
+  margin-bottom: 2rem;
+  border: none;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.guide-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.guide-card-body {
+  display: grid;
+  grid-template-columns: 200px 1fr;
+  gap: 2rem;
+  padding: 1.5rem;
+}
+
+.guide-image-section {
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+}
+
+.guide-image {
+  width: 180px;
+  height: 180px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 4px solid #f8f9fa;
+}
+
+.guide-placeholder {
+  width: 180px;
+  height: 180px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #ff8800 0%, #cc6600 100%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 4px solid #f8f9fa;
+}
+
+.guide-initials {
+  font-size: 3.5rem;
+  font-weight: bold;
+  color: white;
+  text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+.guide-info-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.guide-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+}
+
+.guide-name {
+  font-size: 1.75rem;
+  font-weight: bold;
+  margin: 0;
+  color: #333;
+}
+
+.guide-role {
+  font-size: 1.1rem;
+  color: #666;
+  margin: 0.25rem 0 0 0;
+  font-style: italic;
+}
+
+.experience-badge {
+  font-size: 0.9rem;
+  padding: 0.5rem 1rem;
+}
+
+.guide-bio {
+  font-size: 1rem;
+  color: #555;
+  line-height: 1.6;
+  margin: 0;
+}
+
+.guide-specialties {
+  margin-top: 0.5rem;
+}
+
+.specialties-title {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+  color: #333;
+}
+
+.specialties-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.specialty-badge {
+  font-size: 0.875rem;
+  padding: 0.375rem 0.75rem;
+  font-weight: normal;
+}
+
+.guide-admin-actions {
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid #dee2e6;
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+  .guide-card-body {
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+  }
+
+  .guide-image-section {
+    justify-content: center;
+  }
+
+  .guide-header {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .experience-badge {
+    align-self: flex-start;
+  }
+}
+
+@media (max-width: 576px) {
+  .guide-image,
+  .guide-placeholder {
+    width: 140px;
+    height: 140px;
+  }
+
+  .guide-initials {
+    font-size: 2.5rem;
+  }
+
+  .guide-name {
+    font-size: 1.5rem;
+  }
+}

--- a/src/components/navBar/Navbar.js
+++ b/src/components/navBar/Navbar.js
@@ -18,6 +18,9 @@ export function NavBar() {
               <Link to="/" className="navLink">
                 Home
               </Link>
+              <Link to="/about" className="navLink">
+                About
+              </Link>
               <Link to="/seasons" className="navLink">
                 Seasons
               </Link>

--- a/src/pages/aboutPage/About.js
+++ b/src/pages/aboutPage/About.js
@@ -1,0 +1,148 @@
+import { useState } from "react";
+import { useSelector, useDispatch } from "react-redux";
+import { Container, Badge, Row, Col, Button } from "react-bootstrap";
+import {
+  toggleAdminMode,
+  setEditingSection,
+  clearEditingSection,
+  deleteGuide,
+} from "../../slice/AboutSlice";
+import { EditableSection } from "../../components/editableSection/EditableSection";
+import { GuideCard } from "../../components/guideCard/GuideCard";
+import { AboutEditModal } from "../../components/aboutEditModal/AboutEditModal";
+import "./about.css";
+
+export function About() {
+  const dispatch = useDispatch();
+  const { familyHistory, guides, conservation, ethics, isAdminMode, editingSection } =
+    useSelector((state) => state.aboutSlice);
+
+  const [clickCount, setClickCount] = useState(0);
+  const [clickTimeout, setClickTimeout] = useState(null);
+  const [editingGuideId, setEditingGuideId] = useState(null);
+
+  const handleTripleClick = () => {
+    setClickCount((prev) => prev + 1);
+
+    if (clickTimeout) {
+      clearTimeout(clickTimeout);
+    }
+
+    const timeout = setTimeout(() => {
+      if (clickCount + 1 >= 3) {
+        dispatch(toggleAdminMode());
+      }
+      setClickCount(0);
+    }, 500);
+
+    setClickTimeout(timeout);
+  };
+
+  const handleEditSection = (section) => {
+    dispatch(setEditingSection(section));
+  };
+
+  const handleEditGuide = (guideId) => {
+    setEditingGuideId(guideId);
+    dispatch(setEditingSection("guide"));
+  };
+
+  const handleDeleteGuide = (guideId) => {
+    if (
+      window.confirm("Are you sure you want to delete this guide? This action cannot be undone.")
+    ) {
+      dispatch(deleteGuide(guideId));
+    }
+  };
+
+  const handleCloseModal = () => {
+    dispatch(clearEditingSection());
+    setEditingGuideId(null);
+  };
+
+  return (
+    <>
+      <div className="secondary-hero">
+        <Container>
+          <h1 onClick={handleTripleClick} style={{ cursor: "pointer" }}>
+            <span>About Us</span>
+            {isAdminMode && (
+              <Badge bg="warning" className="ms-3">
+                Admin Mode
+              </Badge>
+            )}
+          </h1>
+        </Container>
+      </div>
+
+      <Container className="about-page-content">
+        <EditableSection
+          section={familyHistory}
+          isAdminMode={isAdminMode}
+          onEdit={() => handleEditSection("familyHistory")}
+          className="family-history-section"
+        />
+
+        <section className="guides-section">
+          <div className="section-heading">
+            <h2>Meet Our Guides</h2>
+          </div>
+          <Row>
+            {guides.map((guide) => (
+              <Col key={guide.id} md={12} lg={6} className="mb-4">
+                <GuideCard
+                  guide={guide}
+                  isAdminMode={isAdminMode}
+                  onEdit={handleEditGuide}
+                  onDelete={handleDeleteGuide}
+                />
+              </Col>
+            ))}
+          </Row>
+          {isAdminMode && (
+            <div className="text-center mt-3">
+              <Button
+                variant="success"
+                onClick={() => {
+                  // In a real app, this would add a new guide
+                  alert("Add new guide feature - would create a blank guide form");
+                }}
+              >
+                Add New Guide
+              </Button>
+            </div>
+          )}
+        </section>
+
+        <EditableSection
+          section={{
+            title: conservation.title,
+            content: conservation.content,
+            listItems: conservation.practices,
+          }}
+          isAdminMode={isAdminMode}
+          onEdit={() => handleEditSection("conservation")}
+          className="conservation-section"
+        />
+
+        <EditableSection
+          section={{
+            title: ethics.title,
+            content: ethics.content,
+            listItems: ethics.principles,
+          }}
+          isAdminMode={isAdminMode}
+          onEdit={() => handleEditSection("ethics")}
+          className="ethics-section"
+        />
+      </Container>
+
+      <AboutEditModal
+        show={editingSection !== null}
+        section={editingSection}
+        guideId={editingGuideId}
+        onHide={handleCloseModal}
+      />
+    </>
+  );
+}

--- a/src/pages/aboutPage/about.css
+++ b/src/pages/aboutPage/about.css
@@ -1,0 +1,65 @@
+.about-page-content {
+  padding: 2rem 0;
+  max-width: 1400px;
+}
+
+.family-history-section {
+  margin-bottom: 3rem;
+}
+
+.guides-section {
+  margin: 3rem 0;
+}
+
+.guides-section .section-heading {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.guides-section .section-heading h2 {
+  font-size: 2.5rem;
+  font-weight: bold;
+  color: #333;
+  position: relative;
+  display: inline-block;
+}
+
+.guides-section .section-heading h2::after {
+  content: "";
+  display: block;
+  width: 100px;
+  height: 4px;
+  background: linear-gradient(90deg, #ff8800, #cc6600);
+  margin: 1rem auto 0;
+}
+
+.conservation-section,
+.ethics-section {
+  margin-bottom: 3rem;
+}
+
+/* Admin mode badge */
+.ms-3 {
+  margin-left: 1rem;
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+  .about-page-content {
+    padding: 1rem 0;
+  }
+
+  .guides-section .section-heading h2 {
+    font-size: 2rem;
+  }
+
+  .family-history-section,
+  .conservation-section,
+  .ethics-section {
+    margin-bottom: 2rem;
+  }
+
+  .guides-section {
+    margin: 2rem 0;
+  }
+}

--- a/src/slice/AboutSlice.js
+++ b/src/slice/AboutSlice.js
@@ -1,0 +1,122 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+const initialState = {
+  familyHistory: {
+    id: 1,
+    title: "Our Heritage",
+    content:
+      "Founded in 1952 by the Wilson family, Big Bucks Outfitters has been guiding hunters through Montana's pristine wilderness for over 70 years. What started as a small family operation has grown into a legacy of conservation, ethical hunting, and unforgettable outdoor experiences.",
+    imageUrl: null,
+  },
+  guides: [
+    {
+      id: 1,
+      name: "Jake Wilson",
+      role: "Head Guide & Owner",
+      bio: "Third-generation outfitter with 25 years of experience in Montana backcountry.",
+      yearsExperience: 25,
+      specialties: ["Elk", "Mule Deer", "Backcountry Navigation"],
+      imageUrl: null,
+    },
+    {
+      id: 2,
+      name: "Sarah Martinez",
+      role: "Senior Guide",
+      bio: "Wildlife biologist turned hunting guide, specializing in ethical harvesting and conservation education.",
+      yearsExperience: 15,
+      specialties: ["Whitetail", "Black Bear", "Wildlife Biology"],
+      imageUrl: null,
+    },
+    {
+      id: 3,
+      name: "Tom Blackwood",
+      role: "Lead Wilderness Guide",
+      bio: "Former search and rescue specialist with unmatched knowledge of Montana's wilderness terrain.",
+      yearsExperience: 18,
+      specialties: ["Mountain Hunting", "Safety & First Aid", "Wilderness Survival"],
+      imageUrl: null,
+    },
+  ],
+  conservation: {
+    id: 1,
+    title: "Conservation & Sustainability",
+    content:
+      "At Big Bucks Outfitters, we believe in giving back to the land that provides us with so much. Our commitment to conservation goes beyond compliance—it's a core value.",
+    practices: [
+      "Partner with Montana Fish, Wildlife & Parks for habitat restoration",
+      "Maintain sustainable harvest quotas below legal limits",
+      "Donate 10% of profits to local wildlife conservation organizations",
+      "Practice Leave No Trace principles on all guided hunts",
+      "Educate hunters on ethical shot placement and quick, humane kills",
+      "Support predator management programs for ecosystem balance",
+    ],
+  },
+  ethics: {
+    id: 1,
+    title: "Hunting Ethics & Philosophy",
+    content:
+      "We believe hunting is a privilege that comes with profound responsibility. Our philosophy centers on respect—for the animal, the land, and the tradition.",
+    principles: [
+      "Fair Chase: No baiting, no fenced hunts, no guaranteed kills",
+      "One Shot, One Kill: Emphasis on marksmanship and ethical shot selection",
+      "Full Utilization: Respect the harvest by using meat, hide, and antlers",
+      "Mentorship: Pass on traditions and ethics to the next generation",
+      "Conservation First: Hunters are the original conservationists",
+      "Safety Above All: No trophy is worth compromising safety",
+    ],
+  },
+  isAdminMode: false,
+  editingSection: null,
+};
+
+const aboutSlice = createSlice({
+  name: "about",
+  initialState,
+  reducers: {
+    setFamilyHistory: (state, action) => {
+      state.familyHistory = { ...state.familyHistory, ...action.payload };
+    },
+    addGuide: (state, action) => {
+      state.guides.push(action.payload);
+    },
+    updateGuide: (state, action) => {
+      const { id, updates } = action.payload;
+      const guideIndex = state.guides.findIndex((guide) => guide.id === id);
+      if (guideIndex !== -1) {
+        state.guides[guideIndex] = { ...state.guides[guideIndex], ...updates };
+      }
+    },
+    deleteGuide: (state, action) => {
+      state.guides = state.guides.filter((guide) => guide.id !== action.payload);
+    },
+    setConservation: (state, action) => {
+      state.conservation = { ...state.conservation, ...action.payload };
+    },
+    setEthics: (state, action) => {
+      state.ethics = { ...state.ethics, ...action.payload };
+    },
+    toggleAdminMode: (state) => {
+      state.isAdminMode = !state.isAdminMode;
+    },
+    setEditingSection: (state, action) => {
+      state.editingSection = action.payload;
+    },
+    clearEditingSection: (state) => {
+      state.editingSection = null;
+    },
+  },
+});
+
+export const {
+  setFamilyHistory,
+  addGuide,
+  updateGuide,
+  deleteGuide,
+  setConservation,
+  setEthics,
+  toggleAdminMode,
+  setEditingSection,
+  clearEditingSection,
+} = aboutSlice.actions;
+
+export default aboutSlice.reducer;

--- a/src/store.js
+++ b/src/store.js
@@ -3,7 +3,8 @@ import formSlice from "./slice/FormSlice";
 import weatherSlice from "./slice/WeatherSlice";
 import packageSlice from "./slice/PackageSlice";
 import seasonsSlice from "./slice/SeasonsSlice";
+import aboutSlice from "./slice/AboutSlice";
 
-export const reducer = combineReducers({ formSlice, weatherSlice, packageSlice, seasonsSlice });
+export const reducer = combineReducers({ formSlice, weatherSlice, packageSlice, seasonsSlice, aboutSlice });
 
 export const store = configureStore({ reducer });


### PR DESCRIPTION
ticket: https://github.com/users/ragtop66goat/projects/2/views/1?pane=issue&itemId=151724323&issue=ragtop66goat%7CuncleBigBucks%7C8

Implemented Redux-managed About page featuring editable sections for company heritage, guide bios with placeholder images, conservation practices, and hunting philosophy. Includes admin mode with triple-click activation and comprehensive test coverage.